### PR TITLE
fix a deprecation notice with latest V, add CI, fix `v check-md .`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: Tests & Formatting
+
+on: [push, pull_request]
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Latest V
+        uses: actions/checkout@v2
+        with:
+          repository: vlang/v
+          path: v
+      - name: Build V
+        run: cd v && make && sudo ./v symlink && cd -
+      - name: Checkout project
+        uses: actions/checkout@v2
+        with:
+          path: idna
+
+      - name: Run tests
+        run: cd idna && v -W -N test .
+
+      - name: Run check-md
+        run: cd idna && v check-md .

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ import fleximus.idna
 
 fn main() {
 	input := 'café'
-	conv  := idna.to_ascii(input)
+	conv := idna.to_ascii(input)
 	conv2 := idna.to_unicode(conv)
 
-	println("$input converts to $conv and back again to $conv2"
+	println('${input} converts to ${conv} and back again to ${conv2}')
 }
 ```
 

--- a/idna.v
+++ b/idna.v
@@ -107,7 +107,7 @@ pub fn decode(input_raw string) string {
     mut i := 0
     mut bias := initial_bias
 
-    mut basic := input.index_u8_last('-'[0])
+    mut basic := input.last_index_u8('-'[0])
     if basic == -1 {
         basic = 0
     }


### PR DESCRIPTION
Running `v fmt -diff .` may be also beneficial on the CI, then it can ensure that the code stays formatted (`v fmt -w .` can do it ... it leads to many unrelated formatting changes here though, so I did not do it in this PR).